### PR TITLE
Configure linter to only allow utf8mb4 charset

### DIFF
--- a/.skeema
+++ b/.skeema
@@ -1,3 +1,11 @@
 [production]
 host=127.0.0.1
 flavor=mysql:5.7
+
+# Example of how to configure errors vs warnings, and configure specific
+# problem detectors.
+# Putting this here will affect all subdirs (so all schemas), but it can be
+# overridden in subdirs if desired.
+errors=bad-charset,bad-engine
+warnings=   # override the default with an empty value, effectively removing detection of other problems
+allow-charset=utf8mb4


### PR DESCRIPTION
Also contains an example of how to reconfigure errors vs warnings.

Since the tables in the employees schema all use latin1, this PR will have an Error status in the CI system. Error annotations for these tables will all be shown in the Checks tab of the PR, but not the Files Changed tab, since the PR did not actually change those files.