### PR TITLE
Modify function to change formatting

### DIFF
--- a/stored_procs_funcs/_as_datetime.sql
+++ b/stored_procs_funcs/_as_datetime.sql
@@ -6,12 +6,9 @@ CREATE DEFINER=`root`@`localhost` FUNCTION `_as_datetime`(txt TINYTEXT) RETURNS 
     COMMENT 'Convert given text to DATETIME or NULL.'
 BEGIN
   declare continue handler for SQLEXCEPTION return NULL;
-  
-  
-  
-  if txt RLIKE '^[0-9]{10}$' then
-    return NULL;
-  end if;
-  RETURN (txt + interval 0 second);
+  IF txt RLIKE '^[0-9]{10}$' THEN
+    RETURN NULL;
+  END IF;
+  RETURN txt + INTERVAL 0 SECOND;
 END//
 DELIMITER ;


### PR DESCRIPTION
Notice how Skeema treats modifications of existing routines as unsafe, requiring --allow-unsafe on the command-line to proceed. This is also reflected here in the CI service.

This occurs because MySQL and MariaDB do not provide a command for modifying routine bodies in-place; instead it is necessary to DROP and then re-CREATE them. It is theoretically possible that your application may attempt to use a routine during the split-second period between those two commands, hence the safety warning.